### PR TITLE
v1.3.3 - honoring global logging level 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes in gin-zerologger will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.3] - 2025-02-28
+
+- Fixed an issue when global logging level conflicts with level-specific logging, log messages were produced unexpectedly:
+  - for example, when global logging level is set to `info` while a 200-level logging is set to `debug`, the logger will suppress any 200-level log messages (thus honoring the `info` global logging level)
+- Enhancement added to the example to support an optionally provided global logging level via an environment variable `LOGGING_LEVEL`
+
+## [1.3.2] - 2024-12-06
+
 ## [1.3.1] - 2023-07-20
 
 - When present in the gin context, adding additional configurable values to the log output

--- a/example/main.go
+++ b/example/main.go
@@ -51,6 +51,9 @@ func main() {
 
 	// attach routes
 	r.GET("/", func(ctx *gin.Context) {
+		log.Trace().Str("level", "trace").Msg("running / route...")
+		log.Debug().Str("level", "debug").Msg("running / route...")
+		log.Info().Str("level", "info").Msg("running / route...")
 		ctx.JSON(http.StatusOK, map[string]string{
 			"message": "hello world!",
 		})

--- a/example/main.go
+++ b/example/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"io"
 	"net/http"
+	"os"
 
 	gzl "github.com/clearchanneloutdoor/gin-zerologger"
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -27,11 +29,23 @@ func (ce *customError) Details() map[string]interface{} {
 func main() {
 	r := gin.New()
 
+	// if a global logging level was passed in via an environment variable
+	// set the global logging level to that level
+	if lvl, ok := os.LookupEnv("LOGGING_LEVEL"); ok {
+		l, err := zerolog.ParseLevel(lvl)
+		if err != nil {
+			log.Fatal().Err(err).Msg("unable to parse log level")
+		}
+		zerolog.SetGlobalLevel(l)
+		log.Info().Str("level", l.String()).Msg("global logging level set")
+	}
+
 	// attach logger and recovery middleware
 	r.Use(gzl.GinZeroLogger(
 		gzl.IncludeRequestBody(gzl.HTTPStatusCodes.EqualToOrGreaterThan200),
 		gzl.PathExclusion("/notlogged"),
 		gzl.LogLevel200(log.Debug()),
+		gzl.LogLevel300(log.Info()),
 		gzl.IncludeContextValues("clientID", "random"),
 	))
 
@@ -39,6 +53,12 @@ func main() {
 	r.GET("/", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, map[string]string{
 			"message": "hello world!",
+		})
+	})
+
+	r.GET("/300", func(ctx *gin.Context) {
+		ctx.JSON(http.StatusPermanentRedirect, map[string]string{
+			"message": "redirecting",
 		})
 	})
 

--- a/example/request.sh
+++ b/example/request.sh
@@ -4,6 +4,11 @@
 echo should log at debug level
 curl -XGET localhost:8080
 
+# should be a log.Info
+echo
+echo should log at info level
+curl -XGET localhost:8080/300
+
 # should be a log.Warn
 echo
 echo should log at warn level

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,8 @@ func logEventWithContext(sts int, search *optionsSearch, lctx zerolog.Context, m
 	var lgr *zerolog.Event
 	l := lctx.Logger()
 
+	// lvlspc is a flag to indicate if there is a level-specific logging level
+	lvlspc := false
 	for lvl, key := range map[int]string{
 		5: "default500",
 		4: "default400",
@@ -41,6 +43,9 @@ func logEventWithContext(sts int, search *optionsSearch, lctx zerolog.Context, m
 
 		// check to see if there is a specific logging level to use
 		if dle, ok := search.Find(key); ok {
+			// there is a level-specific logging level
+			lvlspc = true
+
 			switch val := dle.Value.(type) {
 			case *zerolog.Event:
 				if val != nil {
@@ -87,6 +92,19 @@ func logEventWithContext(sts int, search *optionsSearch, lctx zerolog.Context, m
 		}
 	}
 
+	if lvlspc {
+		// the global log level could be higher than the level-specific log level
+		// in that case, the lgr will be nil
+		if lgr == nil {
+			// let's honor global log level by not logging anything
+			return
+		}
+		// honor the level-specific log level if it is set
+		lgr.Send()
+		return
+	}
+
+	// no level-specific logging level was set; let's set up defaults
 	// default 400s to warn
 	if sts >= 400 {
 		lgr = l.Warn()

--- a/logger.go
+++ b/logger.go
@@ -99,9 +99,6 @@ func logEventWithContext(sts int, search *optionsSearch, lctx zerolog.Context, m
 			// let's honor global log level by not logging anything
 			return
 		}
-		// honor the level-specific log level if it is set
-		lgr.Send()
-		return
 	}
 
 	// no level-specific logging level was set; let's set up defaults


### PR DESCRIPTION
- Fixed an issue when global logging level conflicts with level-specific logging, log messages were produced unexpectedly:
  - for example, when global logging level is set to `info` while a 200-level logging is set to `debug`, the logger will suppress any 200-level log messages (thus honoring the `info` global logging level)
- Enhancement added to the example to support an optionally provided global logging level via an environment variable `LOGGING_LEVEL`


[RTBS-1973](https://clearchanneloutdoor.atlassian.net/browse/RTBS-1973)


[RTBS-1973]: https://clearchanneloutdoor.atlassian.net/browse/RTBS-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ